### PR TITLE
Fix Android products arriving in GDScript as an opaque JavaObject

### DIFF
--- a/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
+++ b/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
@@ -25,7 +25,6 @@ import org.godotengine.godot.Godot
 import org.godotengine.godot.plugin.GodotPlugin
 import org.godotengine.godot.plugin.SignalInfo
 import org.godotengine.godot.plugin.UsedByGodot
-import java.util.ArrayList
 
 class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
 
@@ -270,14 +269,23 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
 
             onError = { error ->
                 val result = Dictionary()
-                result["products"] = ArrayList<Dictionary>()
+                // Empty Object[] (not ArrayList) — see the onGetStoreProducts note below.
+                result["products"] = arrayOfNulls<Any>(0)
                 result["error"] = error.message ?: ""
                 emitOnMain("products", result)
             },
 
             onGetStoreProducts = { products ->
-                val list = ArrayList<Dictionary>()
-
+                // Emit the products as an Object[] of Dictionary, NOT a java.util.ArrayList.
+                // Godot's JNI (jni_utils.cpp _jobject_to_variant) converts "[Ljava.lang.Object;"
+                // to a Godot Array, recursing into each element (so each Dictionary becomes a
+                // Godot Dictionary). It has no conversion case for java.util.ArrayList/List, so
+                // an ArrayList reaches GDScript as an opaque JavaObject whose .get(i) returns
+                // null — products/prices never load. Note Array<Dictionary> does NOT work either:
+                // the JNI check is an exact match on "[Ljava.lang.Object;", and Dictionary[] is
+                // "[Lorg.godotengine.godot.Dictionary;".
+                val arr = arrayOfNulls<Any>(products.size)
+                var i = 0
                 for (p in products) {
                     val d = Dictionary()
                     d["id"] = p.id
@@ -285,11 +293,11 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
                     d["description"] = p.description
                     d["price"] = p.price.formatted
                     d["amount"] = p.price.amountMicros / 1_000_000.0
-                    list.add(d)
+                    arr[i++] = d
                 }
 
                 val result = Dictionary()
-                result["products"] = list
+                result["products"] = arr
                 result["error"] = ""
                 emitOnMain("products", result)
             }

--- a/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
+++ b/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
@@ -275,16 +275,16 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
             },
 
             onGetStoreProducts = { products ->
-                val arr = arrayOfNulls<Any>(products.size)
-                var i = 0
-                for (p in products) {
-                    val d = Dictionary()
-                    d["id"] = p.id
-                    d["title"] = p.title
-                    d["description"] = p.description
-                    d["price"] = p.price.formatted
-                    d["amount"] = p.price.amountMicros / 1_000_000.0
-                    arr[i++] = d
+                val arr = Array<Any>(products.size) { index ->
+                    val p = products[index]
+
+                    Dictionary().apply {
+                        this["id"] = p.id
+                        this["title"] = p.title
+                        this["description"] = p.description
+                        this["price"] = p.price.formatted
+                        this["amount"] = p.price.amountMicros / 1_000_000.0
+                    }
                 }
 
                 val result = Dictionary()

--- a/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
+++ b/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
@@ -269,21 +269,12 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
 
             onError = { error ->
                 val result = Dictionary()
-                // Empty Object[] (not ArrayList) — see the onGetStoreProducts note below.
-                result["products"] = arrayOfNulls<Any>(0)
+                result["products"] = emptyArray<Any>()
                 result["error"] = error.message ?: ""
                 emitOnMain("products", result)
             },
 
             onGetStoreProducts = { products ->
-                // Emit the products as an Object[] of Dictionary, NOT a java.util.ArrayList.
-                // Godot's JNI (jni_utils.cpp _jobject_to_variant) converts "[Ljava.lang.Object;"
-                // to a Godot Array, recursing into each element (so each Dictionary becomes a
-                // Godot Dictionary). It has no conversion case for java.util.ArrayList/List, so
-                // an ArrayList reaches GDScript as an opaque JavaObject whose .get(i) returns
-                // null — products/prices never load. Note Array<Dictionary> does NOT work either:
-                // the JNI check is an exact match on "[Ljava.lang.Object;", and Dictionary[] is
-                // "[Lorg.godotengine.godot.Dictionary;".
                 val arr = arrayOfNulls<Any>(products.size)
                 var i = 0
                 for (p in products) {


### PR DESCRIPTION
## Problem

On Android, `fetch_products` never delivers usable products to GDScript. The price/products silently fail to load even though RevenueCat returns the product correctly.

The `products` signal emits the list as a `java.util.ArrayList<Dictionary>`. Godot's Android JNI converter (`platform/android/jni_utils.cpp`, `_jobject_to_variant`) has conversion cases for:

- `[Ljava.lang.Object;` → `Array` (recursing into each element)
- `[Ljava.lang.String;` → `PackedStringArray`
- `org.godotengine.godot.Dictionary` / `HashMap` → `Dictionary`

…but **no case for `java.util.ArrayList` / `List`**. So the list reaches GDScript as an opaque `JavaObject`, and `raw.call("get", i)` returns `null` — the product dictionaries are unreachable.

Symptom in GDScript:
```
products payload: products_type=JavaObject size=1 first=<null>
```

## Fix

Emit the products as an `Object[]` (`arrayOfNulls<Any>`) instead of an `ArrayList`. The JNI converts `[Ljava.lang.Object;` to a Godot `Array` and recurses into each `Dictionary` element.

> Note: `Array<Dictionary>` (`Dictionary[]`) does **not** work — the JNI check is an exact string match on `"[Ljava.lang.Object;"`, and `Dictionary[]` is `"[Lorg.godotengine.godot.Dictionary;"`, which falls through to the opaque-object path. It must be a plain `Object[]`.

## Verification

Built and run on a physical device (Godot 4.6.2, RevenueCat 10.1.2, Android arm64). GDScript now receives a typed `Array` of product dictionaries:
```
products payload: products_type=Array size=1 first={id=… title=… price=…}
```
Product fetch, purchase, and restore all work end-to-end.

Scope is intentionally limited to this marshalling bug — no behavior or API changes.