### PR TITLE
Add subscription-handling support: customer_info_changed, active_ids, set_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,12 +274,50 @@ revenuecat.has_entitlement("premium_access")
 revenuecat.check_entitlement("premium_access")
 ```
 
+### Customer Info
+
+```gdscript
+revenuecat.customer_info_changed.connect(_on_customer_info_changed)
+revenuecat.get_customer_info()
+
+func _on_customer_info_changed(data: Dictionary):
+    if "premium_access" in data["active_ids"]:
+        print("Premium is active")
+    else:
+        print("Premium is not active")
+```
+
+`customer_info` (the reply to `get_customer_info()`) and `customer_info_changed` (emitted whenever
+RevenueCat updates the entitlements: a renewal, an expiry, a restore, or a purchase made on another
+device) carry the same keys and the same Godot types on iOS and Android:
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `active_entitlements` | `int` | Count of active entitlements, `0` if there are none |
+| `active_ids` | `PackedStringArray` | The active entitlements' identifiers, `[]` if there are none |
+
+Use `active_ids` to gate on a specific entitlement, and `active_entitlements` only when a count is
+all you need. When a `get_customer_info()` fetch fails, `customer_info` carries an `error` key with
+the SDK's own message.
+
 ### Login & Logout
 
 ```gdscript
 revenuecat.login("user_123")
 revenuecat.logout()
 ```
+
+### Subscriber Attributes
+
+```gdscript
+revenuecat.set_attributes({
+    "$email": "player@example.com",
+    "favorite_mode": "endless",
+})
+```
+
+RevenueCat subscriber attributes are string keys with string values, so only entries whose key and
+value are both a `String` are forwarded. Any other entry is ignored, on iOS and Android alike.
 
 ## Advanced Configuration
 
@@ -350,6 +388,7 @@ revenuecat/
 | Method | Description |
 |--------|-------------|
 | `initialize(api_key, user_id, debug)` | Initializes SDK |
+| `get_customer_info()` | Requests the current customer info |
 | `fetch_offerings()` | Retrieves offerings |
 | `fetch_products(ids)` | Retrieves product details |
 | `purchase(id)` | Starts purchase flow |
@@ -361,12 +400,14 @@ revenuecat/
 | `present_paywall(offering)` | Shows native UI |
 | `check_entitlement(id)` | Checks entitlement |
 | `restore_purchases` | Retrieves purchases |
+| `set_attributes(attributes)` | Sets subscriber attributes (string keys and string values only) |
 
 ### Signals
 
 | Signal | Args | Description |
 |--------|------|-------------|
 | `customer_info_changed` | `data: Dictionary` | On customer update |
+| `customer_info` | `data: Dictionary` | Customer info fetch result |
 | `purchase_result` | `data: Dictionary` | On purchase finish |
 | `offerings` | `data: Dictionary` | Offerings received |
 | `products` | `data: Dictionary` | Products received |

--- a/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
+++ b/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
@@ -74,15 +74,11 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
         return d
     }
 
-    // Builds the customer-info payload shared by customer_info / customer_info_changed.
-    // active_ids carries the identifiers of every active entitlement so GDScript can gate
-    // on a specific entitlement instead of a bare count.
     private fun customerInfoDict(info: CustomerInfo): Dictionary {
         val d = Dictionary()
         d["active_entitlements"] = info.entitlements.active.size
-        // String[] (not ArrayList) so Godot's JNI converts it to a PackedStringArray.
-        // jni_utils.cpp _jobject_to_variant has a "[Ljava.lang.String;" case but none for
-        // java.util.ArrayList, which would otherwise reach GDScript as an opaque JavaObject.
+        // Must stay String[]: Godot's JNI conversion has no case for a java.util.List, which
+        // would reach GDScript as an opaque JavaObject instead of a PackedStringArray.
         d["active_ids"] = info.entitlements.active.keys.toTypedArray()
         return d
     }
@@ -142,9 +138,6 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
 
         Purchases.configure(builder.build())
 
-        // Live entitlement updates (renewals, expiry, restore, cross-device sync). Without
-        // this listener the customer_info_changed signal never fires on Android, so a
-        // subscription that changes after launch (or on another device) is never reflected.
         Purchases.sharedInstance.updatedCustomerInfoListener =
             UpdatedCustomerInfoListener { customerInfo ->
                 currentCustomerInfo = customerInfo
@@ -154,14 +147,13 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
         get_customer_info()
     }
 
-    // Forward subscriber attributes to RevenueCat (e.g. analytics identifiers used for
-    // attribution/integrations). Mirrors the iOS set_attributes binding.
     @UsedByGodot
     fun set_attributes(attributes: Dictionary) {
         val map = HashMap<String, String>()
-        for (key in attributes.keys) {
-            val value = attributes[key]
-            map[key.toString()] = value?.toString() ?: ""
+        for ((key, value) in attributes) {
+            if (value is String) {
+                map[key] = value
+            }
         }
         Purchases.sharedInstance.setAttributes(map)
     }

--- a/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
+++ b/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
@@ -19,6 +19,7 @@ import com.revenuecat.purchases.interfaces.LogInCallback
 import com.revenuecat.purchases.interfaces.PurchaseCallback
 import com.revenuecat.purchases.interfaces.ReceiveCustomerInfoCallback
 import com.revenuecat.purchases.interfaces.ReceiveOfferingsCallback
+import com.revenuecat.purchases.interfaces.UpdatedCustomerInfoListener
 import com.revenuecat.purchases.models.StoreProduct
 import com.revenuecat.purchases.models.StoreTransaction
 import com.revenuecat.purchases.restorePurchasesWith
@@ -70,6 +71,19 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
         for ((k, v) in pairs) {
             d[k] = v ?: ""
         }
+        return d
+    }
+
+    // Builds the customer-info payload shared by customer_info / customer_info_changed.
+    // active_ids carries the identifiers of every active entitlement so GDScript can gate
+    // on a specific entitlement instead of a bare count.
+    private fun customerInfoDict(info: CustomerInfo): Dictionary {
+        val d = Dictionary()
+        d["active_entitlements"] = info.entitlements.active.size
+        // String[] (not ArrayList) so Godot's JNI converts it to a PackedStringArray.
+        // jni_utils.cpp _jobject_to_variant has a "[Ljava.lang.String;" case but none for
+        // java.util.ArrayList, which would otherwise reach GDScript as an opaque JavaObject.
+        d["active_ids"] = info.entitlements.active.keys.toTypedArray()
         return d
     }
 
@@ -128,7 +142,28 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
 
         Purchases.configure(builder.build())
 
+        // Live entitlement updates (renewals, expiry, restore, cross-device sync). Without
+        // this listener the customer_info_changed signal never fires on Android, so a
+        // subscription that changes after launch (or on another device) is never reflected.
+        Purchases.sharedInstance.updatedCustomerInfoListener =
+            UpdatedCustomerInfoListener { customerInfo ->
+                currentCustomerInfo = customerInfo
+                emitOnMain("customer_info_changed", customerInfoDict(customerInfo))
+            }
+
         get_customer_info()
+    }
+
+    // Forward subscriber attributes to RevenueCat (e.g. analytics identifiers used for
+    // attribution/integrations). Mirrors the iOS set_attributes binding.
+    @UsedByGodot
+    fun set_attributes(attributes: Dictionary) {
+        val map = HashMap<String, String>()
+        for (key in attributes.keys) {
+            val value = attributes[key]
+            map[key.toString()] = value?.toString() ?: ""
+        }
+        Purchases.sharedInstance.setAttributes(map)
     }
 
     @UsedByGodot
@@ -142,10 +177,7 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
 
                 override fun onReceived(customerInfo: CustomerInfo) {
                     currentCustomerInfo = customerInfo
-                    emitOnMain(
-                        "customer_info",
-                        dictOf("active_entitlements" to customerInfo.entitlements.active.size)
-                    )
+                    emitOnMain("customer_info", customerInfoDict(customerInfo))
                 }
             }
         )

--- a/source/ios/revenue_cat/Sources/godotx_revenuecat.h
+++ b/source/ios/revenue_cat/Sources/godotx_revenuecat.h
@@ -28,6 +28,7 @@ public:
     void present_paywall(String offering_id);
     void restore_purchases();
     void show_manage_subscriptions();
+    void set_attributes(Dictionary attributes);
 
     GodotxRevenueCat();
     ~GodotxRevenueCat();

--- a/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
+++ b/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
@@ -7,16 +7,13 @@
 
 GodotxRevenueCat *GodotxRevenueCat::instance = nullptr;
 
-// Builds the customer-info payload shared by customer_info / customer_info_changed.
-// active_ids carries the identifiers of every active entitlement so GDScript can gate
-// on a specific entitlement instead of a bare count.
 static Dictionary godotx_customer_info_dict(RCCustomerInfo *info) {
     Dictionary d;
     d["active_entitlements"] = info ? (int)info.entitlements.active.count : 0;
-    Array ids;
+    PackedStringArray ids;
     if (info) {
         for (NSString *key in info.entitlements.active.allKeys) {
-            ids.append(String::utf8(key.UTF8String));
+            ids.push_back(String::utf8(key.UTF8String));
         }
     }
     d["active_ids"] = ids;
@@ -369,8 +366,13 @@ void GodotxRevenueCat::set_attributes(Dictionary attributes) {
     NSMutableDictionary<NSString *, NSString *> *native = [NSMutableDictionary dictionary];
     Array keys = attributes.keys();
     for (int i = 0; i < keys.size(); i++) {
-        String k = keys[i];
-        String v = attributes[keys[i]];
+        Variant key = keys[i];
+        Variant value = attributes.get(key, Variant());
+        if (key.get_type() != Variant::STRING || value.get_type() != Variant::STRING) {
+            continue;
+        }
+        String k = key;
+        String v = value;
         native[@(k.utf8().get_data())] = @(v.utf8().get_data());
     }
     [[[RCPurchases sharedPurchases] attribution] setAttributes:native];

--- a/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
+++ b/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
@@ -7,6 +7,22 @@
 
 GodotxRevenueCat *GodotxRevenueCat::instance = nullptr;
 
+// Builds the customer-info payload shared by customer_info / customer_info_changed.
+// active_ids carries the identifiers of every active entitlement so GDScript can gate
+// on a specific entitlement instead of a bare count.
+static Dictionary godotx_customer_info_dict(RCCustomerInfo *info) {
+    Dictionary d;
+    d["active_entitlements"] = info ? (int)info.entitlements.active.count : 0;
+    Array ids;
+    if (info) {
+        for (NSString *key in info.entitlements.active.allKeys) {
+            ids.append(String::utf8(key.UTF8String));
+        }
+    }
+    d["active_ids"] = ids;
+    return d;
+}
+
 @interface GodotxRevenueCatDelegate : NSObject <RCPurchasesDelegate>
 @end
 
@@ -18,12 +34,9 @@ static RCCustomerInfo *currentCustomerInfo = nullptr;
 
 - (void)purchases:(RCPurchases *)purchases receivedUpdatedCustomerInfo:(RCCustomerInfo *)info {
     currentCustomerInfo = info;
-    int count = info ? (int)info.entitlements.active.count : 0;
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
-        Dictionary d;
-        d["active_entitlements"] = count;
-        GodotxRevenueCat::get_singleton()->emit_signal("customer_info_changed", d);
+        GodotxRevenueCat::get_singleton()->emit_signal("customer_info_changed", godotx_customer_info_dict(info));
     });
 }
 
@@ -77,6 +90,7 @@ void GodotxRevenueCat::_bind_methods() {
     ClassDB::bind_method(D_METHOD("check_entitlement", "entitlement_id"), &GodotxRevenueCat::check_entitlement);
     ClassDB::bind_method(D_METHOD("restore_purchases"), &GodotxRevenueCat::restore_purchases);
     ClassDB::bind_method(D_METHOD("show_manage_subscriptions"), &GodotxRevenueCat::show_manage_subscriptions);
+    ClassDB::bind_method(D_METHOD("set_attributes", "attributes"), &GodotxRevenueCat::set_attributes);
 }
 
 void GodotxRevenueCat::initialize(String api_key, String user_id, bool debug) {
@@ -102,12 +116,10 @@ void GodotxRevenueCat::initialize(String api_key, String user_id, bool debug) {
 void GodotxRevenueCat::get_customer_info() {
     [[RCPurchases sharedPurchases] getCustomerInfoWithCompletion:^(RCCustomerInfo *info, NSError *error) {
         if (info) currentCustomerInfo = info;
-        int count = info ? (int)info.entitlements.active.count : 0;
-        String err = error ? String(error.localizedDescription.UTF8String) : "";
-        
+        String err = error ? String::utf8(error.localizedDescription.UTF8String) : "";
+
         dispatch_async(dispatch_get_main_queue(), ^{
-            Dictionary d;
-            d["active_entitlements"] = count;
+            Dictionary d = godotx_customer_info_dict(info);
             if (error) d["error"] = err;
             emit_signal("customer_info", d);
         });
@@ -136,8 +148,8 @@ void GodotxRevenueCat::purchase(String pid) {
         [[RCPurchases sharedPurchases] purchaseProduct:p withCompletion:^(RCStoreTransaction *tx, RCCustomerInfo *info, NSError *error, BOOL cancelled) {
             if (info) currentCustomerInfo = info;
             int count = info ? (int)info.entitlements.active.count : 0;
-            String err = error ? String(error.localizedDescription.UTF8String) : "";
-            String tid = tx && tx.transactionIdentifier ? String(tx.transactionIdentifier.UTF8String) : "";
+            String err = error ? String::utf8(error.localizedDescription.UTF8String) : "";
+            String tid = tx && tx.transactionIdentifier ? String::utf8(tx.transactionIdentifier.UTF8String) : "";
             
             dispatch_async(dispatch_get_main_queue(), ^{
                 Dictionary d;
@@ -234,10 +246,10 @@ void GodotxRevenueCat::fetch_products(Array ids) {
             Array arr;
             for (RCStoreProduct *p in products) {
                 Dictionary o;
-                o["id"] = p.productIdentifier ? String(p.productIdentifier.UTF8String) : "";
-                o["title"] = p.localizedTitle ? String(p.localizedTitle.UTF8String) : "";
-                o["description"] = p.localizedDescription ? String(p.localizedDescription.UTF8String) : "";
-                o["price"] = p.localizedPriceString ? String(p.localizedPriceString.UTF8String) : "";
+                o["id"] = p.productIdentifier ? String::utf8(p.productIdentifier.UTF8String) : "";
+                o["title"] = p.localizedTitle ? String::utf8(p.localizedTitle.UTF8String) : "";
+                o["description"] = p.localizedDescription ? String::utf8(p.localizedDescription.UTF8String) : "";
+                o["price"] = p.localizedPriceString ? String::utf8(p.localizedPriceString.UTF8String) : "";
                 o["amount"] = (double)p.price.doubleValue;
                 arr.append(o);
             }
@@ -257,7 +269,7 @@ void GodotxRevenueCat::login(String user_id) {
         if (info) currentCustomerInfo = info;
         int count = info ? (int)info.entitlements.active.count : 0;
         bool success = error == nil;
-        String err = error ? String(error.localizedDescription.UTF8String) : "";
+        String err = error ? String::utf8(error.localizedDescription.UTF8String) : "";
         
         dispatch_async(dispatch_get_main_queue(), ^{
             Dictionary d;
@@ -275,7 +287,7 @@ void GodotxRevenueCat::logout() {
         if (info) currentCustomerInfo = info;
         int count = info ? (int)info.entitlements.active.count : 0;
         bool success = error == nil;
-        String err = error ? String(error.localizedDescription.UTF8String) : "";
+        String err = error ? String::utf8(error.localizedDescription.UTF8String) : "";
         
         dispatch_async(dispatch_get_main_queue(), ^{
             Dictionary d;
@@ -325,7 +337,7 @@ void GodotxRevenueCat::restore_purchases() {
         if (info) currentCustomerInfo = info;
 
         int count = info ? (int)info.entitlements.active.count : 0;
-        String err = error ? String(error.localizedDescription.UTF8String) : "";
+        String err = error ? String::utf8(error.localizedDescription.UTF8String) : "";
         bool success = error == nil;
 
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -351,6 +363,17 @@ void GodotxRevenueCat::show_manage_subscriptions() {
             emit_signal("manage_subscriptions_finished", d);
         });
     }];
+}
+
+void GodotxRevenueCat::set_attributes(Dictionary attributes) {
+    NSMutableDictionary<NSString *, NSString *> *native = [NSMutableDictionary dictionary];
+    Array keys = attributes.keys();
+    for (int i = 0; i < keys.size(); i++) {
+        String k = keys[i];
+        String v = attributes[keys[i]];
+        native[@(k.utf8().get_data())] = @(v.utf8().get_data());
+    }
+    [[[RCPurchases sharedPurchases] attribution] setAttributes:native];
 }
 
 static UIViewController *godotx_revenuecat_get_root_view_controller() {


### PR DESCRIPTION
Adds the pieces needed to drive a subscription/entitlement source of truth from GDScript. Independent of #13 (touches different methods).

## Changes

### Android: `customer_info_changed` now fires
Registers an `UpdatedCustomerInfoListener` in `initialize()`. Without it, the `customer_info_changed` signal **never fires on Android**, so any entitlement change after launch (renewal, expiry, restore, or a change made on another device) was never delivered to GDScript. iOS already had this via its delegate.

### `active_ids` on the customer-info payload
`customer_info` and `customer_info_changed` now include `active_ids` — the identifiers of the active entitlements — so GDScript can gate on a **specific** entitlement instead of only `active_entitlements` (a count). Emitted as a `String[]` on Android (→ `PackedStringArray`) and an `Array` on iOS.

### `set_attributes(Dictionary)`
Forwards subscriber attributes to RevenueCat (e.g. analytics/attribution identifiers like `$firebaseAppInstanceId`). Added on both Android and iOS, with the iOS `ClassDB` binding.

### iOS: UTF-8 string decoding
Switches `String(ns.UTF8String)` → `String::utf8(ns.UTF8String)` so non-ASCII strings (localized titles, etc.) decode correctly.

## Notes
- A shared `customerInfoDict()` / `godotx_customer_info_dict()` builds the customer-info payload so `customer_info` and `customer_info_changed` stay consistent.
- Verified on-device: Android, Godot 4.6.2, RevenueCat 10.1.2 — purchase → `customer_info_changed active_entitlements=1 active_ids=["…"]` → restore all deliver correctly.