### PR TITLE
Add support for Godot 4.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ APPLE_SDK_ARCHS  = iphoneos/arm64 iphonesimulator/arm64 iphonesimulator/x86_64
 # ============================================================================
 # Version Configuration
 # ============================================================================
-GODOT_VERSION = 4.6-stable
+GODOT_VERSION = 4.7-stable
 GODOT_REPO    = https://github.com/godotengine/godot.git
 REVENUECAT_VERSION = 5.67.2
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This project provides a native RevenueCat plugin for Godot, built as a fully int
 
 | Component | Version |
 |-----------|---------|
-| Godot | 4.6‑stable |
+| Godot | 4.7‑stable |
 | RevenueCat iOS SDK | 5.67.2 |
 | RevenueCat Android SDK | 10.1.2 |
 | Kotlin | 2.3.0 |

--- a/addons/godotx_revenue_cat/plugin.cfg
+++ b/addons/godotx_revenue_cat/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godotx RevenueCat"
 description="RevenueCat integration for Godot"
 author="Paulo Coutinho"
-version="2.1.0"
+version="2.2.0"
 script="export_plugin.gd"

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="GodotxRevenueCatSample"
 run/main_scene="res://scenes/Main.tscn"
-config/features=PackedStringArray("4.6")
+config/features=PackedStringArray("4.7")
 
 [display]
 

--- a/source/android/revenue_cat/build.gradle.kts
+++ b/source/android/revenue_cat/build.gradle.kts
@@ -31,11 +31,10 @@ android {
 }
 
 dependencies {
-    compileOnly("org.godotengine:godot:4.6.0.stable")
+    compileOnly("org.godotengine:godot:4.7.0.stable")
 
     // RevenueCat
     implementation("com.revenuecat.purchases:purchases:10.1.2")
     implementation("com.revenuecat.purchases:purchases-ui:10.1.2")
     implementation("androidx.appcompat:appcompat:1.7.1")
 }
-


### PR DESCRIPTION
## Summary

  Adds support for Godot `4.7-stable`.

## Changes

  - Updates the default Godot build version to `4.7-stable`
  - Updates the Android Godot dependency to `org.godotengine:godot:4.7.0.stable`
  - Updates the sample/project feature tag to `4.7`
  - Bumps the plugin version to `2.2.0`
  - Updates the README compatibility table for Godot 4.7

## Verification

  - Built Android plugin with `make build-android`
  - Generated Godot 4.7 headers with `make build-godot-headers`
  - Built Apple plugin with `make build-apple`
  - Built release package with `make package`