### PR TITLE
Add show_manage_subscriptions binding for the native manage-subscriptions sheet

### DIFF
--- a/addons/godotx_revenue_cat/plugin.cfg
+++ b/addons/godotx_revenue_cat/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godotx RevenueCat"
 description="RevenueCat integration for Godot"
 author="Paulo Coutinho"
-version="2.3.0"
+version="2.4.0"
 script="export_plugin.gd"

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -195,6 +195,14 @@ theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_font_sizes/font_size = 28
 text = "Restore Purchases"
 
+[node name="ManageSubscriptionsButton" type="Button" parent="VBoxContainer/ScrollContainer/Content/SectionPurchases/SectionPurchasesVBox"]
+custom_minimum_size = Vector2(0, 70)
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(1, 1, 1, 1)
+theme_override_font_sizes/font_size = 28
+text = "Manage Subscriptions"
+
 [node name="SectionOfferings" type="PanelContainer" parent="VBoxContainer/ScrollContainer/Content"]
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_1")
@@ -447,6 +455,7 @@ text = "Clear Log"
 [connection signal="pressed" from="VBoxContainer/ScrollContainer/Content/SectionCustomerInfo/SectionCustomerInfoVBox/GetCustomerInfoButton" to="." method="_on_get_customer_info_pressed"]
 [connection signal="pressed" from="VBoxContainer/ScrollContainer/Content/SectionPurchases/SectionPurchasesVBox/PurchaseButton" to="." method="_on_purchase_pressed"]
 [connection signal="pressed" from="VBoxContainer/ScrollContainer/Content/SectionPurchases/SectionPurchasesVBox/RestorePurchasesButton" to="." method="_on_restore_purchases_pressed"]
+[connection signal="pressed" from="VBoxContainer/ScrollContainer/Content/SectionPurchases/SectionPurchasesVBox/ManageSubscriptionsButton" to="." method="_on_manage_subscriptions_pressed"]
 [connection signal="pressed" from="VBoxContainer/ScrollContainer/Content/SectionOfferings/SectionOfferingsVBox/FetchOfferingsButton" to="." method="_on_fetch_offerings_pressed"]
 [connection signal="pressed" from="VBoxContainer/ScrollContainer/Content/SectionProducts/SectionProductsVBox/FetchProductsHBox/FetchProductsButton" to="." method="_on_fetch_products_pressed"]
 [connection signal="pressed" from="VBoxContainer/ScrollContainer/Content/SectionLogin/SectionLoginVBox/LoginHBox/LoginButton" to="." method="_on_login_pressed"]

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -86,6 +86,9 @@ func connect_signals() -> void:
 	revenuecat.paywall_result.connect(_on_paywall_result)
 	revenuecat.restore_finished.connect(_on_restore_finished)
 
+	if revenuecat.has_signal("manage_subscriptions_finished"):
+		revenuecat.manage_subscriptions_finished.connect(_on_manage_subscriptions_finished)
+
 	log_message("🔌 Connected all RevenueCat signals")
 
 
@@ -221,6 +224,16 @@ func _on_restore_purchases_pressed():
 	log_message("➡️ restore_purchases()")
 
 
+func _on_manage_subscriptions_pressed():
+	if revenuecat == null:
+		return
+	if not revenuecat.has_method("show_manage_subscriptions"):
+		log_message("⚠️ show_manage_subscriptions() not available on this platform")
+		return
+	revenuecat.show_manage_subscriptions()
+	log_message("➡️ show_manage_subscriptions()")
+
+
 func _on_clear_log_pressed():
 	log_output.text = ""
 
@@ -312,4 +325,9 @@ func _on_paywall_result(data):
 
 func _on_restore_finished(data):
 	log_message("🔔 SIGNAL: restore_finished")
+	log_message(dict_to_string(data))
+
+
+func _on_manage_subscriptions_finished(data):
+	log_message("🔔 SIGNAL: manage_subscriptions_finished")
 	log_message(dict_to_string(data))

--- a/source/ios/revenue_cat/Sources/godotx_revenuecat.h
+++ b/source/ios/revenue_cat/Sources/godotx_revenuecat.h
@@ -26,6 +26,7 @@ public:
     void check_entitlement(String entitlement_id);
     void present_paywall(String offering_id);
     void restore_purchases();
+    void show_manage_subscriptions();
 
     GodotxRevenueCat();
     ~GodotxRevenueCat();

--- a/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
+++ b/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
@@ -61,6 +61,7 @@ void GodotxRevenueCat::_bind_methods() {
     ADD_SIGNAL(MethodInfo("entitlement", PropertyInfo(Variant::STRING, "id"), PropertyInfo(Variant::BOOL, "active")));
     ADD_SIGNAL(MethodInfo("paywall_result", PropertyInfo(Variant::DICTIONARY, "data")));
     ADD_SIGNAL(MethodInfo("restore_finished", PropertyInfo(Variant::DICTIONARY, "data")));
+    ADD_SIGNAL(MethodInfo("manage_subscriptions_finished", PropertyInfo(Variant::DICTIONARY, "data")));
 
     ClassDB::bind_method(D_METHOD("initialize", "api_key", "user_id", "debug"), &GodotxRevenueCat::initialize);
     ClassDB::bind_method(D_METHOD("get_customer_info"), &GodotxRevenueCat::get_customer_info);
@@ -74,6 +75,7 @@ void GodotxRevenueCat::_bind_methods() {
     ClassDB::bind_method(D_METHOD("present_paywall", "offering_id"), &GodotxRevenueCat::present_paywall);
     ClassDB::bind_method(D_METHOD("check_entitlement", "entitlement_id"), &GodotxRevenueCat::check_entitlement);
     ClassDB::bind_method(D_METHOD("restore_purchases"), &GodotxRevenueCat::restore_purchases);
+    ClassDB::bind_method(D_METHOD("show_manage_subscriptions"), &GodotxRevenueCat::show_manage_subscriptions);
 }
 
 void GodotxRevenueCat::initialize(String api_key, String user_id, bool debug) {
@@ -282,6 +284,20 @@ void GodotxRevenueCat::restore_purchases() {
             d["active_entitlements"] = count;
             if (error) d["error"] = err;
             emit_signal("restore_finished", d);
+        });
+    }];
+}
+
+void GodotxRevenueCat::show_manage_subscriptions() {
+    [[RCPurchases sharedPurchases] showManageSubscriptionsWithCompletion:^(NSError *error) {
+        String err = error ? String::utf8(error.localizedDescription.UTF8String) : "";
+        bool success = error == nil;
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            Dictionary d;
+            d["success"] = success;
+            if (error) d["error"] = err;
+            emit_signal("manage_subscriptions_finished", d);
         });
     }];
 }


### PR DESCRIPTION
Adds an iOS-only bound method, show_manage_subscriptions, that wraps Purchases.showManageSubscriptions(completion:) so the native App Store subscription management sheet can be presented in-app. The outcome is reported back through a new manage_subscriptions_finished signal, following the same pattern as the existing restore_purchases binding.

The sample scene gets a "Manage Subscriptions" button and log handler wired up for manual testing, alongside the existing purchase/restore controls.

This is independent of PR #14 and does not depend on it.