### PR TITLE
Feature: Offering packages and purchase package

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,57 @@ func _on_purchase_result(data):
 
 ```gdscript
 # Offerings
+revenuecat.offerings.connect(_on_offerings_received)
 revenuecat.fetch_offerings()
 
+func _on_offerings_received(data: Dictionary):
+    var error = data.get("error", "")
+    if error != "":
+        print("Error: ", error)
+        return
+
+    # The current offering's identifier, and its packages ready to display.
+    print("Current offering: ", data["identifier"])
+
+    for pkg in data["packages"]:
+        var product = pkg["product"]
+        print("Package: ", pkg["identifier"], " (", pkg["package_type"], ")")
+        print("  ", product["title"], " - ", product["price"])
+
+    # Every offering, including the current one.
+    for offering in data["offerings"]:
+        print(offering["identifier"], " has ", offering["packages"].size(), " packages")
+```
+
+The `offerings` signal carries the same keys and the same Godot types on iOS and Android:
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `error` | `String` | `""` when the fetch succeeded |
+| `identifier` | `String` | The current offering's identifier, `""` if there is none |
+| `packages` | `Array` | The current offering's packages, `[]` if there is none |
+| `offerings` | `Array` | Every offering: `{ "identifier": String, "packages": Array }` |
+
+Each entry of a `packages` array is a `Dictionary`:
+
+| Key | Type | Example |
+|-----|------|---------|
+| `identifier` | `String` | `"$rc_monthly"` |
+| `package_type` | `String` | `"MONTHLY"`, `"ANNUAL"`, `"SIX_MONTH"`, `"THREE_MONTH"`, `"TWO_MONTH"`, `"WEEKLY"`, `"LIFETIME"`, `"CUSTOM"`, `"UNKNOWN"` |
+| `product` | `Dictionary` | The underlying store product |
+
+Each `product` uses the same keys as `fetch_products`, plus `currency`:
+
+| Key | Type | Example |
+|-----|------|---------|
+| `id` | `String` | `"premium_monthly"` |
+| `title` | `String` | `"Premium"` |
+| `description` | `String` | `"Unlock everything"` |
+| `price` | `String` | `"$4.99"` (localized) |
+| `amount` | `float` | `4.99` |
+| `currency` | `String` | `"USD"` |
+
+```gdscript
 # Products (for custom UI)
 revenuecat.products.connect(_on_products_received)
 revenuecat.fetch_products(["premium_monthly", "premium_yearly"])
@@ -172,6 +221,19 @@ func _on_products_received(data: Dictionary):
 ```gdscript
 revenuecat.purchase("premium_monthly")
 ```
+
+Purchase a package from an offering instead of a bare product id. Pass `""` as the offering id to
+use the current offering. This is the only way to buy a Google Play subscription that has more than
+one base plan, because the `Package` carries the base plan and a product id cannot.
+
+```gdscript
+revenuecat.purchase_package("", "$rc_monthly")
+revenuecat.purchase_package("default", "$rc_annual")
+```
+
+Both paths emit the same `purchase_result` dictionary, so a single handler serves both. On failure
+`error` is one of the SDK's own messages or `offering_not_found`, `package_not_found`, or
+`activity_null` (Android only, as with `purchase`).
 
 ```gdscript
 revenuecat.restore_purchases()
@@ -270,6 +332,7 @@ revenuecat/
 | `fetch_offerings()` | Retrieves offerings |
 | `fetch_products(ids)` | Retrieves product details |
 | `purchase(id)` | Starts purchase flow |
+| `purchase_package(offering_id, package_id)` | Starts purchase flow for a package (`offering_id` `""` = current offering) |
 | `login(user_id)` | Authenticate user |
 | `logout()` | Anonymous reset |
 | `is_subscriber()` | Returns subscription state |

--- a/README.md
+++ b/README.md
@@ -236,8 +236,29 @@ Both paths emit the same `purchase_result` dictionary, so a single handler serve
 `activity_null` (Android only, as with `purchase`).
 
 ```gdscript
+revenuecat.restore_finished.connect(_on_restore_finished)
 revenuecat.restore_purchases()
+
+func _on_restore_finished(data: Dictionary):
+    if not data["success"]:
+        print("Restore failed: ", data["error"])
+        return
+
+    if data["restored"]:
+        print("Restored ", data["active_entitlements"], " entitlements")
+    else:
+        print("Nothing to restore")
 ```
+
+`restore_finished` always fires — once, on success and on failure alike — and carries the same keys
+and the same Godot types on iOS and Android:
+
+| Key | Type | Notes |
+|-----|------|-------|
+| `success` | `bool` | `false` only when the restore itself failed |
+| `restored` | `bool` | `true` when at least one entitlement is active afterwards |
+| `active_entitlements` | `int` | Count of active entitlements, `0` on failure |
+| `error` | `String` | The SDK's own message, `""` on success |
 
 ### Show Native Paywall
 

--- a/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
+++ b/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
@@ -6,7 +6,9 @@ import androidx.core.content.ContextCompat
 import com.revenuecat.purchases.CacheFetchPolicy
 import com.revenuecat.purchases.CustomerInfo
 import com.revenuecat.purchases.LogLevel
+import com.revenuecat.purchases.Offering
 import com.revenuecat.purchases.Offerings
+import com.revenuecat.purchases.Package
 import com.revenuecat.purchases.PurchaseParams
 import com.revenuecat.purchases.Purchases
 import com.revenuecat.purchases.PurchasesConfiguration
@@ -223,6 +225,78 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
         })
     }
 
+    private fun emitPurchaseResult(
+        cancelled: Boolean,
+        entitlements: Int,
+        error: String,
+        productId: String,
+        transactionId: String
+    ) {
+        val d = Dictionary()
+        d["cancelled"] = cancelled
+        d["active_entitlements"] = entitlements
+        d["error"] = error
+        d["product_id"] = productId
+        d["transaction_id"] = transactionId
+        emitOnMain("purchase_result", d)
+    }
+
+    @UsedByGodot
+    fun purchase_package(offering_id: String, package_id: String) {
+        val a = act()
+        if (a == null) {
+            emitPurchaseResult(false, 0, "activity_null", "", "")
+            return
+        }
+
+        Purchases.sharedInstance.getOfferings(object : ReceiveOfferingsCallback {
+            override fun onError(error: PurchasesError) {
+                emitPurchaseResult(false, 0, error.message, "", "")
+            }
+
+            override fun onReceived(offerings: Offerings) {
+                val offering =
+                    if (offering_id.isNotEmpty()) offerings.all[offering_id] else offerings.current
+
+                if (offering == null) {
+                    emitPurchaseResult(false, 0, "offering_not_found", "", "")
+                    return
+                }
+
+                val pkg = offering.availablePackages.firstOrNull { it.identifier == package_id }
+
+                if (pkg == null) {
+                    emitPurchaseResult(false, 0, "package_not_found", "", "")
+                    return
+                }
+
+                // Purchasing the Package (not a re-resolved product id) is what carries the
+                // Google Play base plan / subscriptionOption that purchase(String) cannot express.
+                val params = PurchaseParams.Builder(a, pkg).build()
+
+                Purchases.sharedInstance.purchase(params, object : PurchaseCallback {
+                    override fun onError(error: PurchasesError, userCancelled: Boolean) {
+                        emitPurchaseResult(userCancelled, 0, error.message, pkg.product.id, "")
+                    }
+
+                    override fun onCompleted(
+                        storeTransaction: StoreTransaction,
+                        customerInfo: CustomerInfo
+                    ) {
+                        currentCustomerInfo = customerInfo
+                        emitPurchaseResult(
+                            false,
+                            customerInfo.entitlements.active.size,
+                            "",
+                            pkg.product.id,
+                            storeTransaction.orderId ?: ""
+                        )
+                    }
+                })
+            }
+        })
+    }
+
     @UsedByGodot
     fun restore_purchases() {
         Purchases.sharedInstance.restorePurchasesWith() { customerInfo ->
@@ -240,23 +314,64 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
         }
     }
 
+    private fun productDict(product: StoreProduct): Dictionary {
+        return Dictionary().apply {
+            this["id"] = product.id
+            this["title"] = product.title
+            this["description"] = product.description
+            this["price"] = product.price.formatted
+            this["amount"] = product.price.amountMicros / 1_000_000.0
+            this["currency"] = product.price.currencyCode
+        }
+    }
+
+    private fun packageDict(pkg: Package): Dictionary {
+        return Dictionary().apply {
+            this["identifier"] = pkg.identifier
+            this["package_type"] = pkg.packageType.name
+            this["product"] = productDict(pkg.product)
+        }
+    }
+
+    // Object[], never ArrayList and never Array<Dictionary>: Godot's JNI
+    // (jni_utils.cpp _jobject_to_variant) matches exactly "[Ljava.lang.Object;" to build a
+    // Godot Array, recursing into each element. Anything else reaches GDScript as an opaque
+    // JavaObject. Same constraint fetch_products is written against.
+    private fun packagesArray(packages: List<Package>): Array<Any> {
+        return Array<Any>(packages.size) { index -> packageDict(packages[index]) }
+    }
+
+    private fun offeringsArray(offerings: List<Offering>): Array<Any> {
+        return Array<Any>(offerings.size) { index ->
+            Dictionary().apply {
+                this["identifier"] = offerings[index].identifier
+                this["packages"] = packagesArray(offerings[index].availablePackages)
+            }
+        }
+    }
+
     @UsedByGodot
     fun fetch_offerings() {
         Purchases.sharedInstance.getOfferings(
             object : ReceiveOfferingsCallback {
                 override fun onError(error: PurchasesError) {
-                    emitOnMain("offerings", dictOf("error" to error.message))
+                    val result = Dictionary()
+                    result["error"] = error.message
+                    result["identifier"] = ""
+                    result["packages"] = emptyArray<Any>()
+                    result["offerings"] = emptyArray<Any>()
+                    emitOnMain("offerings", result)
                 }
 
                 override fun onReceived(offerings: Offerings) {
                     val current = offerings.current
-                    emitOnMain(
-                        "offerings",
-                        dictOf(
-                            "identifier" to (current?.identifier ?: ""),
-                            "available_packages" to (current?.availablePackages?.size ?: 0)
-                        )
-                    )
+
+                    val result = Dictionary()
+                    result["error"] = ""
+                    result["identifier"] = current?.identifier ?: ""
+                    result["packages"] = packagesArray(current?.availablePackages ?: emptyList())
+                    result["offerings"] = offeringsArray(offerings.all.values.toList())
+                    emitOnMain("offerings", result)
                 }
             }
         )

--- a/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
+++ b/source/android/revenue_cat/src/main/java/com/godotx/revenuecat/RevenueCatPlugin.kt
@@ -297,21 +297,29 @@ class RevenueCatPlugin(godot: Godot) : GodotPlugin(godot) {
         })
     }
 
+    private fun emitRestoreFinished(success: Boolean, entitlements: Int, error: String) {
+        emitOnMain(
+            "restore_finished",
+            dictOf(
+                "success" to success,
+                "restored" to (entitlements > 0),
+                "active_entitlements" to entitlements,
+                "error" to error
+            )
+        )
+    }
+
     @UsedByGodot
     fun restore_purchases() {
-        Purchases.sharedInstance.restorePurchasesWith() { customerInfo ->
-            currentCustomerInfo = customerInfo
-
-            val restoredCount = customerInfo.entitlements.active.size
-
-            emitOnMain(
-                "restore_finished",
-                dictOf(
-                    "active_entitlements" to restoredCount,
-                    "restored" to (restoredCount > 0)
-                )
-            )
-        }
+        Purchases.sharedInstance.restorePurchasesWith(
+            onError = { error ->
+                emitRestoreFinished(false, 0, error.message)
+            },
+            onSuccess = { customerInfo ->
+                currentCustomerInfo = customerInfo
+                emitRestoreFinished(true, customerInfo.entitlements.active.size, "")
+            }
+        )
     }
 
     private fun productDict(product: StoreProduct): Dictionary {

--- a/source/ios/revenue_cat/Sources/godotx_revenuecat.h
+++ b/source/ios/revenue_cat/Sources/godotx_revenuecat.h
@@ -17,6 +17,7 @@ public:
     void initialize(String api_key, String user_id, bool debug);
     void get_customer_info();
     void purchase(String product_id);
+    void purchase_package(String offering_id, String package_id);
     void fetch_offerings();
     void fetch_products(Array ids);
     void login(String user_id);

--- a/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
+++ b/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
@@ -101,7 +101,7 @@ void GodotxRevenueCat::initialize(String api_key, String user_id, bool debug) {
 
 void GodotxRevenueCat::get_customer_info() {
     [[RCPurchases sharedPurchases] getCustomerInfoWithCompletion:^(RCCustomerInfo *info, NSError *error) {
-        currentCustomerInfo = info;
+        if (info) currentCustomerInfo = info;
         int count = info ? (int)info.entitlements.active.count : 0;
         String err = error ? String(error.localizedDescription.UTF8String) : "";
         
@@ -134,7 +134,7 @@ void GodotxRevenueCat::purchase(String pid) {
         RCStoreProduct *p = products.firstObject;
         
         [[RCPurchases sharedPurchases] purchaseProduct:p withCompletion:^(RCStoreTransaction *tx, RCCustomerInfo *info, NSError *error, BOOL cancelled) {
-            currentCustomerInfo = info;
+            if (info) currentCustomerInfo = info;
             int count = info ? (int)info.entitlements.active.count : 0;
             String err = error ? String(error.localizedDescription.UTF8String) : "";
             String tid = tx && tx.transactionIdentifier ? String(tx.transactionIdentifier.UTF8String) : "";
@@ -254,7 +254,7 @@ void GodotxRevenueCat::login(String user_id) {
     NSString *uid = @(user_id.utf8().get_data());
     
     [[RCPurchases sharedPurchases] logIn:uid completion:^(RCCustomerInfo *info, BOOL created, NSError *error) {
-        currentCustomerInfo = info;
+        if (info) currentCustomerInfo = info;
         int count = info ? (int)info.entitlements.active.count : 0;
         bool success = error == nil;
         String err = error ? String(error.localizedDescription.UTF8String) : "";
@@ -272,7 +272,7 @@ void GodotxRevenueCat::login(String user_id) {
 
 void GodotxRevenueCat::logout() {
     [[RCPurchases sharedPurchases] logOutWithCompletion:^(RCCustomerInfo *info, NSError *error) {
-        currentCustomerInfo = info;
+        if (info) currentCustomerInfo = info;
         int count = info ? (int)info.entitlements.active.count : 0;
         bool success = error == nil;
         String err = error ? String(error.localizedDescription.UTF8String) : "";
@@ -298,7 +298,7 @@ void GodotxRevenueCat::check_entitlement(String entitlement_id) {
     NSString *eid = @(entitlement_id.utf8().get_data());
     
     [[RCPurchases sharedPurchases] getCustomerInfoWithCompletion:^(RCCustomerInfo *info, NSError *error) {
-        currentCustomerInfo = info;
+        if (info) currentCustomerInfo = info;
         bool active = false;
         
         if (info) {
@@ -322,7 +322,7 @@ bool GodotxRevenueCat::has_entitlement(String entitlement_id) {
 
 void GodotxRevenueCat::restore_purchases() {
     [[RCPurchases sharedPurchases] restorePurchasesWithCompletion:^(RCCustomerInfo *info, NSError *error) {
-        currentCustomerInfo = info;
+        if (info) currentCustomerInfo = info;
 
         int count = info ? (int)info.entitlements.active.count : 0;
         String err = error ? String(error.localizedDescription.UTF8String) : "";
@@ -481,7 +481,7 @@ void GodotxRevenueCat::purchase_package(String offering_id, String package_id) {
         // Purchasing the Package (not a re-resolved product id) is what carries the
         // store-side subscription option that purchase(String) cannot express.
         [[RCPurchases sharedPurchases] purchasePackage:pkg withCompletion:^(RCStoreTransaction *tx, RCCustomerInfo *info, NSError *purchase_error, BOOL cancelled) {
-            currentCustomerInfo = info;
+            if (info) currentCustomerInfo = info;
             int count = info ? (int)info.entitlements.active.count : 0;
             String err = purchase_error ? String(purchase_error.localizedDescription.UTF8String) : "";
             String tid = tx && tx.transactionIdentifier ? String(tx.transactionIdentifier.UTF8String) : "";

--- a/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
+++ b/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
@@ -66,6 +66,7 @@ void GodotxRevenueCat::_bind_methods() {
     ClassDB::bind_method(D_METHOD("initialize", "api_key", "user_id", "debug"), &GodotxRevenueCat::initialize);
     ClassDB::bind_method(D_METHOD("get_customer_info"), &GodotxRevenueCat::get_customer_info);
     ClassDB::bind_method(D_METHOD("purchase", "product_id"), &GodotxRevenueCat::purchase);
+    ClassDB::bind_method(D_METHOD("purchase_package", "offering_id", "package_id"), &GodotxRevenueCat::purchase_package);
     ClassDB::bind_method(D_METHOD("fetch_offerings"), &GodotxRevenueCat::fetch_offerings);
     ClassDB::bind_method(D_METHOD("fetch_products", "ids"), &GodotxRevenueCat::fetch_products);
     ClassDB::bind_method(D_METHOD("login", "user_id"), &GodotxRevenueCat::login);
@@ -151,22 +152,71 @@ void GodotxRevenueCat::purchase(String pid) {
     }];
 }
 
+// Matches PackageType.name on Android (the Kotlin enum constant name), so package_type is
+// the same string on both platforms. Not RCPackage.stringFrom:, which yields "$rc_monthly".
+static String godotx_revenuecat_package_type_name(RCPackageType type) {
+    switch (type) {
+        case RCPackageTypeCustom: return "CUSTOM";
+        case RCPackageTypeLifetime: return "LIFETIME";
+        case RCPackageTypeAnnual: return "ANNUAL";
+        case RCPackageTypeSixMonth: return "SIX_MONTH";
+        case RCPackageTypeThreeMonth: return "THREE_MONTH";
+        case RCPackageTypeTwoMonth: return "TWO_MONTH";
+        case RCPackageTypeMonthly: return "MONTHLY";
+        case RCPackageTypeWeekly: return "WEEKLY";
+        default: return "UNKNOWN";
+    }
+}
+
+static Dictionary godotx_revenuecat_product_dict(RCStoreProduct *p) {
+    Dictionary o;
+    o["id"] = p.productIdentifier ? String(p.productIdentifier.UTF8String) : "";
+    o["title"] = p.localizedTitle ? String(p.localizedTitle.UTF8String) : "";
+    o["description"] = p.localizedDescription ? String(p.localizedDescription.UTF8String) : "";
+    o["price"] = p.localizedPriceString ? String(p.localizedPriceString.UTF8String) : "";
+    o["amount"] = (double)p.price.doubleValue;
+    o["currency"] = p.currencyCode ? String(p.currencyCode.UTF8String) : "";
+    return o;
+}
+
+static Array godotx_revenuecat_packages_array(NSArray<RCPackage *> *packages) {
+    Array arr;
+    for (RCPackage *pkg in packages) {
+        Dictionary d;
+        d["identifier"] = pkg.identifier ? String(pkg.identifier.UTF8String) : "";
+        d["package_type"] = godotx_revenuecat_package_type_name(pkg.packageType);
+        d["product"] = godotx_revenuecat_product_dict(pkg.storeProduct);
+        arr.append(d);
+    }
+    return arr;
+}
+
 void GodotxRevenueCat::fetch_offerings() {
     [[RCPurchases sharedPurchases] getOfferingsWithCompletion:^(RCOfferings *offers, NSError *error) {
-        String identifier = "";
-        int count = 0;
-        String err = error ? String(error.localizedDescription.UTF8String) : "";
-        
-        if (!error && offers && offers.current) {
-            identifier = String(offers.current.identifier.UTF8String);
-            count = (int)offers.current.availablePackages.count;
-        }
-        
         dispatch_async(dispatch_get_main_queue(), ^{
             Dictionary d;
-            if (error) d["error"] = err;
-            d["identifier"] = identifier;
-            d["packages_count"] = count;
+            d["error"] = error ? String(error.localizedDescription.UTF8String) : "";
+            d["identifier"] = "";
+            d["packages"] = Array();
+            d["offerings"] = Array();
+
+            if (!error && offers) {
+                Array all;
+                for (NSString *key in offers.all) {
+                    RCOffering *off = offers.all[key];
+                    Dictionary o;
+                    o["identifier"] = off.identifier ? String(off.identifier.UTF8String) : "";
+                    o["packages"] = godotx_revenuecat_packages_array(off.availablePackages);
+                    all.append(o);
+                }
+                d["offerings"] = all;
+
+                if (offers.current) {
+                    d["identifier"] = String(offers.current.identifier.UTF8String);
+                    d["packages"] = godotx_revenuecat_packages_array(offers.current.availablePackages);
+                }
+            }
+
             emit_signal("offerings", d);
         });
     }];
@@ -374,5 +424,70 @@ void GodotxRevenueCat::present_paywall(String offering_id) {
             
             [root presentViewController:pw animated:YES completion:nil];
         });
+    }];
+}
+
+static void godotx_revenuecat_emit_purchase_result(bool cancelled, int entitlements, const String &error, const String &product_id, const String &transaction_id) {
+    Dictionary d;
+    d["cancelled"] = cancelled;
+    d["active_entitlements"] = entitlements;
+    d["error"] = error;
+    d["product_id"] = product_id;
+    d["transaction_id"] = transaction_id;
+    GodotxRevenueCat::get_singleton()->emit_signal("purchase_result", d);
+}
+
+void GodotxRevenueCat::purchase_package(String offering_id, String package_id) {
+    NSString *oid = offering_id.is_empty() ? nil : @(offering_id.utf8().get_data());
+    NSString *pkg_id = @(package_id.utf8().get_data());
+
+    [[RCPurchases sharedPurchases] getOfferingsWithCompletion:^(RCOfferings *offers, NSError *error) {
+        if (error || !offers) {
+            String err = error ? String(error.localizedDescription.UTF8String) : "offering_not_found";
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                godotx_revenuecat_emit_purchase_result(false, 0, err, "", "");
+            });
+            return;
+        }
+
+        RCOffering *off = oid ? offers.all[oid] : offers.current;
+
+        if (!off) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                godotx_revenuecat_emit_purchase_result(false, 0, "offering_not_found", "", "");
+            });
+            return;
+        }
+
+        RCPackage *pkg = nil;
+        for (RCPackage *p in off.availablePackages) {
+            if ([p.identifier isEqualToString:pkg_id]) {
+                pkg = p;
+                break;
+            }
+        }
+
+        if (!pkg) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                godotx_revenuecat_emit_purchase_result(false, 0, "package_not_found", "", "");
+            });
+            return;
+        }
+
+        String pid = pkg.storeProduct.productIdentifier ? String(pkg.storeProduct.productIdentifier.UTF8String) : "";
+
+        // Purchasing the Package (not a re-resolved product id) is what carries the
+        // store-side subscription option that purchase(String) cannot express.
+        [[RCPurchases sharedPurchases] purchasePackage:pkg withCompletion:^(RCStoreTransaction *tx, RCCustomerInfo *info, NSError *purchase_error, BOOL cancelled) {
+            currentCustomerInfo = info;
+            int count = info ? (int)info.entitlements.active.count : 0;
+            String err = purchase_error ? String(purchase_error.localizedDescription.UTF8String) : "";
+            String tid = tx && tx.transactionIdentifier ? String(tx.transactionIdentifier.UTF8String) : "";
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                godotx_revenuecat_emit_purchase_result(cancelled, count, err, pid, tid);
+            });
+        }];
     }];
 }

--- a/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
+++ b/source/ios/revenue_cat/Sources/godotx_revenuecat.mm
@@ -331,8 +331,9 @@ void GodotxRevenueCat::restore_purchases() {
         dispatch_async(dispatch_get_main_queue(), ^{
             Dictionary d;
             d["success"] = success;
+            d["restored"] = count > 0;
             d["active_entitlements"] = count;
-            if (error) d["error"] = err;
+            d["error"] = err;
             emit_signal("restore_finished", d);
         });
     }];


### PR DESCRIPTION
Marshal Offering packages, and fix a silent failure in restore_purchases

Two related fixes that came out of building a custom cross-platform paywall in GDScript.

### Offerings

`fetch_offerings` only ever emitted the current offering's identifier and an integer
package count. It also did so under a different key on each platform (`available_packages` on
Android, `packages_count` on iOS). There was no way to read a package's identifier,
type or localized price from GDScript, so an offering couldn't drive a paywall.

Packages now cross the boundary with the same keys and the same Godot types on both
platforms:

    error       String
    identifier  String
    packages    Array of Dictionary
    offerings   Array of Dictionary

Each package is `{identifier, package_type, product}`, and `product` reuses the keys
`fetch_products` already emits (`id`, `title`, `description`, `price`, `amount`,
`currency`).

Breaking: `available_packages` and `packages_count` are removed. They were an integer
count under two different names, so nothing portable could have relied on them.

### purchase_package

New `purchase_package(offering_id, package_id)`. It purchases the `Package` rather
than re-resolving a product id, which is important for Google Play: `purchase(String)` goes
through `getProducts().first()`, so a subscription with more than one base plan buys
an arbitrary one. Passing the Package carries the base plan through.

### restore_purchases

`restore_purchases` passed a single trailing lambda to `restorePurchasesWith`, which
binds to `onSuccess` because it's the last parameter; so `onError` fell back to
`ON_ERROR_STUB` and a failed restore emitted nothing at all (no signal, no log).

While there: `restore_finished` also disagreed across platforms. Android sent
`{restored, active_entitlements}`, iOS sent `{success, active_entitlements}` and
omitted `error` entirely on success. Both now will always send all four keys, which is
additive and nothing was removed or retyped.

### Testing

CI builds clean.